### PR TITLE
Fix kind flag usage

### DIFF
--- a/vllm.sh
+++ b/vllm.sh
@@ -178,7 +178,7 @@ EOF
     
     # Cluster erstellen
     
-    kind create cluster -config=kind-config.yaml -wait=300s
+    kind create cluster --config kind-config.yaml --wait 300s
     
     # NGINX Ingress Controller installieren
     


### PR DESCRIPTION
## Summary
- use `--config` and `--wait` flags when creating the kind cluster

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688879ced7d88324ac3616cf2f929d6c