### PR TITLE
Add AI stack compose setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Ollama configuration
+OLLAMA_PORT=11434
+OLLAMA_DATA=./ollama
+# Comma separated list of model names to preload
+OLLAMA_MODELS="llama2:latest"
+
+# vLLM configuration
+VLLM_PORT=8000
+VLLM_DATA=./vllm
+VLLM_MODEL="mistralai/Mistral-7B-Instruct-v0.2"
+# Optional token for downloading models
+HUGGINGFACE_TOKEN=
+
+# Gateway configuration
+GATEWAY_PORT=8080

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+
+# Environments
+.env
+
+# Docker
+**/data/
+
+# Misc
+*.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# AI Stack with Ollama and vLLM
+
+This repository provides a minimal yet production oriented setup for running local large language models with [Ollama](https://github.com/ollama/ollama) and [vLLM](https://github.com/vllm-project/vllm). An optional Python gateway can proxy requests to either backend based on the selected model. The stack is prepared for a future migration to Kubernetes.
+
+## Features
+
+- **Ollama** – run multiple models locally
+- **vLLM** – OpenAI compatible API
+- **Gateway** – optional FastAPI proxy
+- Container health checks and volume mounts
+- All configuration via environment variables
+
+## Setup
+
+1. Install Docker and Docker Compose.
+2. Copy `.env.example` to `.env` and adjust the variables if needed.
+3. Run the installation script:
+
+```bash
+./install.sh
+```
+
+This will start the services and verify that all containers become healthy.
+
+### Default Ports
+
+- Ollama: `${OLLAMA_PORT}` (default `11434`)
+- vLLM: `${VLLM_PORT}` (default `8000`)
+- Gateway: `${GATEWAY_PORT}` (default `8080`)
+
+Models will be stored in the directories defined by `OLLAMA_DATA` and `VLLM_DATA`.
+
+## Usage
+
+- **Ollama** API: `http://localhost:${OLLAMA_PORT}`
+- **vLLM** API (OpenAI compatible): `http://localhost:${VLLM_PORT}/v1`
+- **Gateway** (if enabled): `http://localhost:${GATEWAY_PORT}`
+
+Example call against vLLM:
+
+```bash
+curl http://localhost:${VLLM_PORT}/v1/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model": "mistral", "prompt": "Hello"}'
+```
+
+The gateway inspects the model name and forwards the request either to vLLM or Ollama. See `gateway/main.py` for details.
+
+## Extending the Stack
+
+- Add more models by adjusting `OLLAMA_MODELS` and `VLLM_MODEL` in the `.env` file.
+- Connect to cloud LLM providers by adding additional services or extending the gateway.
+- For Kubernetes, use the same images and environment variables in your manifests or Helm charts.
+
+## Gateway
+
+The optional gateway is a small FastAPI application. It listens on `${GATEWAY_PORT}` and forwards requests depending on the model name. If you do not need it, remove the service from `docker-compose.yml`.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,57 @@
+version: '3.8'
+
+services:
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "${OLLAMA_PORT}:11434"
+    volumes:
+      - ${OLLAMA_DATA}:/root/.ollama
+    environment:
+      - OLLAMA_MODELS=${OLLAMA_MODELS}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11434"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  vllm:
+    image: vllm/vllm-openai:latest
+    command: >
+      python3 -m vllm.entrypoints.openai.api_server \
+        --model ${VLLM_MODEL} \
+        --host 0.0.0.0 \
+        --port 8000
+    ports:
+      - "${VLLM_PORT}:8000"
+    volumes:
+      - ${VLLM_DATA}:/root/.cache/huggingface
+    environment:
+      - HUGGING_FACE_HUB_TOKEN=${HUGGINGFACE_TOKEN}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/healthz"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  gateway:
+    build: ./gateway
+    ports:
+      - "${GATEWAY_PORT}:8000"
+    environment:
+      - OLLAMA_URL=http://ollama:11434
+      - VLLM_URL=http://vllm:8000
+    depends_on:
+      ollama:
+        condition: service_healthy
+      vllm:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+volumes:
+  ollama_data:
+  vllm_data:

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY main.py .
+RUN pip install --no-cache-dir fastapi uvicorn httpx
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/gateway/main.py
+++ b/gateway/main.py
@@ -1,0 +1,21 @@
+from fastapi import FastAPI, Request
+import os, httpx
+
+app = FastAPI()
+
+OLLAMA_URL = os.getenv("OLLAMA_URL", "http://ollama:11434")
+VLLM_URL = os.getenv("VLLM_URL", "http://vllm:8000")
+VLLM_MODELS = os.getenv("VLLM_MODEL", "")
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+@app.post("/v1/completions")
+async def completions(req: Request):
+    data = await req.json()
+    model = data.get("model", "")
+    url = VLLM_URL if model in VLLM_MODELS else OLLAMA_URL
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(f"{url}/v1/completions", json=data)
+        return resp.json()

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -e
+
+check_cmd() {
+  command -v "$1" >/dev/null 2>&1 || { echo "Error: $1 is not installed."; exit 1; }
+}
+
+check_cmd docker
+check_cmd docker-compose || check_cmd docker\ compose
+
+if [ ! -f .env ]; then
+  cp .env.example .env
+  echo "Created .env from example"
+fi
+
+docker compose pull
+
+docker compose up -d
+
+echo "Waiting for containers to become healthy..."
+HEALTHY=0
+for i in {1..20}; do
+  unhealthy=$(docker compose ps --format '{{.Name}} {{.Health}}' | awk '$2!="healthy"')
+  if [ -z "$unhealthy" ]; then
+    HEALTHY=1
+    break
+  fi
+  sleep 3
+  echo "Still starting..."
+done
+
+if [ $HEALTHY -eq 1 ]; then
+  echo "All services are healthy."
+else
+  echo "Some services are not healthy:" >&2
+  docker compose ps
+fi
+
+echo "\nUsage instructions:"
+echo "- Ollama: http://localhost:${OLLAMA_PORT:-11434}"
+echo "- vLLM:  http://localhost:${VLLM_PORT:-8000}/v1"
+echo "- Gateway (optional): http://localhost:${GATEWAY_PORT:-8080}"
+


### PR DESCRIPTION
## Summary
- init docker compose stack for ollama, vllm and optional gateway
- provide example environment file
- add install helper script
- document usage in README
- minimal FastAPI gateway

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6888bbe1942c8324851963b9f5c23d57